### PR TITLE
Noise reduction tweak for non OSX

### DIFF
--- a/bin/sem-dist
+++ b/bin/sem-dist
@@ -30,7 +30,7 @@ args = Args.from_stdin(:optional => ['artifact_name', 'tag'])
 
 # On MAC OS X, use gnutar to avoid warnings like
 #   Ignoring unknown extended header keyword `SCHILY.ino'
-tar_cmd = `which gnutar`.strip
+tar_cmd = `which gnutar 2> /dev/null`.strip
 if tar_cmd == ""
   tar_cmd = "tar"
 end


### PR DESCRIPTION
sem-dist ........
which: no gnutar in (/opt/ruby-1.8.7/bin:/home/michael/src/gilt/bin:/home/michael/src/gilt/tools/bin:/opt/apache-ant-1.8.2/bin:/opt/apache-maven-3.0.4/bin:/usr/lib64/qt-3.3/bin:/usr/lib64/ccache:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/local/sbin:/usr/sbin:/home/michael/.local/bin:/home/michael/bin)
...continues...
