### PR TITLE
Ensure that last line of output file is always newline terminated

### DIFF
--- a/bin/sem-add
+++ b/bin/sem-add
@@ -22,7 +22,7 @@ Preconditions.check_state(file.match(/\.sql/i), "File[#{file}] must end with .sq
 scripts_dir = File.join(`pwd`.strip, "scripts")
 Library.ensure_dir!(scripts_dir)
 
-contents = IO.read(file).strip
+contents = IO.read(file).strip + "\n"
 now = Time.now.strftime('%Y%m%d-%H%M%S')
 target = File.join(scripts_dir, "#{now}.sql")
 


### PR DESCRIPTION
Have noticed that the scripts that result from use of sem-add have the last line without a newline. This seems to be happening due to use of strip which strips the string (that stores the contents of input file) of all trailing newlines and when "out << contents" is done the output file has the last line without newline termination.
