### PR TITLE
simplify by moving the script file to scripts dir with proper name

### DIFF
--- a/bin/sem-add
+++ b/bin/sem-add
@@ -27,11 +27,7 @@ now = Time.now.strftime('%Y%m%d-%H%M%S')
 target = File.join(scripts_dir, "#{now}.sql")
 
 puts "Adding #{target}"
-File.open(target, 'w') do |out|
-  out << contents
-end
-
+Library.system_or_error("mv #{file} #{target}")
 Library.system_or_error("git add #{target}")
-Library.system_or_error("rm #{file}")
 
 puts "File staged in git. You need to commit and push"


### PR DESCRIPTION
Since the script file is being moved to scripts directory with contents unchanged, we can simplify the processing. We can avoid the need to open the (input) scripts file for reading and simply move the file as the target file.
