### PR TITLE
dev.rb should use exec so that error messages are clear and exit status ...

### DIFF
--- a/template/dev.rb
+++ b/template/dev.rb
@@ -7,4 +7,4 @@
 
 command = "sem-apply --host localhost --user %%user%% --name %%name%%"
 puts command
-system(command)
+exec(command)


### PR DESCRIPTION
...is correct
- the way that it is written now hides errors that occur when sem-apply
  is not installed, or not on the user's PATH
