### PR TITLE
Add support for DB URL connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ version.
 ### Initialization
 
     git init /tmp/sample
-    sem-init --dir /tmp/sample --name sample_development --user postgres
+    sem-init --dir /tmp/sample --url postgresql://postgres@localhost/sample_development
 
 ### Writing your first sql script
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ version.
 
     cd /tmp/sample
     createdb sample_development
+    sem-apply --url postgresql://postgres@localhost/sample_development
+
+Note that you can also pass in the username, db host, and db name explicitly:
+
     sem-apply --host localhost --name sample_development --user postgres
 
 ### When you are happy with your change, commit:
@@ -190,7 +194,7 @@ fine as well.
 
 ### Do a dry run
 
-    sem-apply --host localhost --name sample_production --user postgres --dry_run
+    sem-apply --url postgresql://postgres@localhost/sample_development --dry_run
 
 You will likely see a number of create table statements (see data model section below). You should also see:
 
@@ -201,7 +205,7 @@ which tells you that if you apply these changes, that sql script will be applied
 
 ### Apply the changes
 
-    sem-apply --host localhost --name sample_production --user postgres
+    sem-apply --url postgresql://postgres@localhost/sample_development
 
 You will see:
 
@@ -210,7 +214,7 @@ You will see:
 
 Attempt to apply again:
 
-    sem-apply --host localhost --name sample_production --user postgres
+    sem-apply --url postgresql://postgres@localhost/sample_development
 
 You will see:
 

--- a/bin/sem-apply
+++ b/bin/sem-apply
@@ -11,7 +11,7 @@
 
 load File.join(File.dirname(__FILE__), 'sem-config')
 
-args = SchemaEvolutionManager::Args.from_stdin(:required => %w(host name user), :optional => %w(dry_run))
+args = SchemaEvolutionManager::Args.from_stdin(:optional => %w(url host name user dry_run))
 
 db = SchemaEvolutionManager::Db.from_args(args)
 db.bootstrap!
@@ -20,7 +20,7 @@ dry_run = args.dry_run.nil? ? false : args.dry_run
 
 util = SchemaEvolutionManager::ApplyUtil.new(db, :dry_run => dry_run)
 
-puts "Upgrading schema for #{db.to_pretty_string}"
+puts "Upgrading schema for #{db.url}"
 
 begin
   count = util.apply!("./scripts")

--- a/bin/sem-apply
+++ b/bin/sem-apply
@@ -3,9 +3,12 @@
 #    sorted by the timestamp assigned at the time the script was added
 #
 # == Usage
+#  sem-apply --url <database url>
+#  or
 #  sem-apply --host <database host> --user <db user> --name <db name>
 #
-# == Example
+# == Examples
+#  sem-apply --url postgresql://postgres@localhost/sample_development
 #  sem-apply --host localhost --user web --name test
 #
 

--- a/bin/sem-dist
+++ b/bin/sem-dist
@@ -2,7 +2,7 @@
 # == Creates a tarball containing SQL scripts that might need to be
 #    applied to a specific postgresql database. This tarball can then
 #    be uploaded, unpacked, and schema changes applied using
-#    software-evolution-manager scripts
+#    schema-evolution-manager scripts
 #
 # == Usage
 #  sem-dist [--artifact_name <tag> --tag <tag>]

--- a/bin/sem-init
+++ b/bin/sem-init
@@ -4,6 +4,8 @@
 #
 # == Usage
 #  sem-init --dir <dir> --url <url>
+#  or
+#  sem-init --dir <dir> --host <database host> --user <db user> --name <db name>
 #
 #   dir: The directory containing a git repository that will contain the schema evolution files
 #   url: The connection string for the psql database
@@ -16,8 +18,9 @@
 load File.join(File.dirname(__FILE__), 'sem-config')
 SchemaEvolutionManager::Library.set_verbose(true)
 
-args = SchemaEvolutionManager::Args.from_stdin(:required => %w(dir url))
+args = SchemaEvolutionManager::Args.from_stdin(:required => %w(dir), :optional => %w(url host name user))
 SchemaEvolutionManager::Preconditions.check_state(File.directory?(args.dir), "Dir[%s] does not exist" % args.dir)
+db = SchemaEvolutionManager::Db.from_args(args)
 
 def copy_file(source, target, substitutions)
   template = SchemaEvolutionManager::Template.new
@@ -35,7 +38,7 @@ SchemaEvolutionManager::Preconditions.check_state(File.directory?(template_dir),
                                                   "Could not find schema-evolution-manager/template subdir. Expected it at[%s]" % [template_dir])
 
 subs = {
-  "url" => args.url,
+  "url" => db.url,
   "add_script_path" => File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-add")
 }
 

--- a/bin/sem-init
+++ b/bin/sem-init
@@ -1,24 +1,23 @@
 #!/usr/bin/env ruby
 # == Initializes an existing git repository to support schema evolutions managed
-#    by software-evolution-manager
+#    by schema-evolution-manager
 #
 # == Usage
-#  sem-init --dir <dir> --name <name> --user <username>
+#  sem-init --dir <dir> --url <url>
 #
 #   dir: The directory containing a git repository that will contain the schema evolution files
-#   name: The name of the actual database that will be managed
-#   user: The postgresql username to connect to this database
+#   url: The connection string for the psql database
 #
 # == Example
 #  git init /tmp/example_repo
-#  bin/sem-init --dir /tmp/example_repo --name example_us_development --user dev
+#  bin/sem-init --dir /tmp/example_repo --url postgresql://username@localhost/sample_development
 #
 
 load File.join(File.dirname(__FILE__), 'sem-config')
 SchemaEvolutionManager::Library.set_verbose(true)
 
-args = SchemaEvolutionManager::Args.from_stdin(:required => %w(name user dir))
-SchemaEvolutionManager::Preconditions.check_state(File.directory?(args.dir), "Dir[%s] does not exist" % [args.dir])
+args = SchemaEvolutionManager::Args.from_stdin(:required => %w(dir url))
+SchemaEvolutionManager::Preconditions.check_state(File.directory?(args.dir), "Dir[%s] does not exist" % args.dir)
 
 def copy_file(source, target, substitutions)
   template = SchemaEvolutionManager::Template.new
@@ -33,15 +32,14 @@ end
 
 template_dir = File.join(SchemaEvolutionManager::Library.base_dir, "template")
 SchemaEvolutionManager::Preconditions.check_state(File.directory?(template_dir),
-                                                  "Could not find software-evolution-manager/template subdir. Expected it at[%s]" % [template_dir])
+                                                  "Could not find schema-evolution-manager/template subdir. Expected it at[%s]" % [template_dir])
 
 subs = {
-  "name" => args.name,
-  "user" => args.user,
+  "url" => args.url,
   "add_script_path" => File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-add")
 }
 
-puts "chdir %s" % [args.dir]
+puts "chdir %s" % args.dir
 Dir.chdir(args.dir) do
 
   wrappers = []
@@ -56,13 +54,13 @@ Dir.chdir(args.dir) do
     end
   end
   if !wrappers.empty?
-    SchemaEvolutionManager::Library.system_or_error("git commit -m 'Add software-evolution-manager wrapper scripts' #{wrappers.join(" ")}")
+    SchemaEvolutionManager::Library.system_or_error("git commit -m 'Add schema-evolution-manager wrapper scripts' #{wrappers.join(" ")}")
   end
 
   readme = "README.md"
   if !File.exists?(readme)
     puts "Creating #{readme}"
-    copy_file("software-evolution-manager/template/README.md", "README.md", subs)
+    copy_file("schema-evolution-manager/template/README.md", "README.md", subs)
     SchemaEvolutionManager::Library.system_or_error("git add #{readme}")
     SchemaEvolutionManager::Library.system_or_error("git commit -m 'Adding README.md' README.md")
   end

--- a/lib/schema-evolution-manager/args.rb
+++ b/lib/schema-evolution-manager/args.rb
@@ -11,6 +11,7 @@ module SchemaEvolutionManager
         :user => "Connect to the database as this username instead of the default",
         :host => "Specifies the host name of the machine on which the server is running",
         :name => "Specifies the name of the database to which to connect",
+        :url => "Connect to the database as this username instead of the default",
         :dir => "Path to a directory",
         :tag => "A git tag (e.g. 0.0.1)",
         :prefix => "Configure installer to use this prefix"
@@ -23,7 +24,7 @@ module SchemaEvolutionManager
       }
     end
 
-    attr_reader :artifact_name, :host, :name, :prefix, :user, :dir, :dry_run, :tag
+    attr_reader :artifact_name, :host, :name, :prefix, :url, :user, :dir, :dry_run, :tag
 
     # args: Actual string arguments
     # :required => list of parameters that are required
@@ -52,6 +53,7 @@ module SchemaEvolutionManager
       @host = found_arguments.delete(:host)
       @name = found_arguments.delete(:name)
       @prefix = found_arguments.delete(:prefix)
+      @url = found_arguments.delete(:url)
       @user = found_arguments.delete(:user)
       @dir = found_arguments.delete(:dir)
       @tag = found_arguments.delete(:tag)

--- a/lib/schema-evolution-manager/library.rb
+++ b/lib/schema-evolution-manager/library.rb
@@ -123,10 +123,14 @@ module SchemaEvolutionManager
         puts command
       end
 
-      result = `#{command}`.strip
-      status = $?
-      if status.to_i > 0
-        raise "Non zero exit code[%s] running command[%s]" % [status, command]
+      begin
+        result = `#{command}`.strip
+        status = $?
+        if status.to_i > 0
+          raise "Non zero exit code[%s] running command[%s]" % [status, command]
+        end
+      rescue Exception => e
+        raise "Error running command[%s]: %s" % [command, e.to_s]
       end
       result
     end

--- a/lib/schema-evolution-manager/script_error.rb
+++ b/lib/schema-evolution-manager/script_error.rb
@@ -10,8 +10,8 @@ module SchemaEvolutionManager
     end
 
     def dml
-      "psql --host %s --username %s --command \"insert into %s.%s (filename) values ('%s')\" %s\n" %
-        [@db.host, @db.user, Db.schema_name, Scripts::SCRIPTS, filename, @db.name]
+      sql_command = "insert into %s.%s (filename) values ('%s')" % [Db.schema_name, Scripts::SCRIPTS, filename]
+      "psql --command \"%s\" %s" % [sql_command, @db.url]
     end
 
   end

--- a/template/dev.rb
+++ b/template/dev.rb
@@ -6,7 +6,7 @@
 #
 
 Dir.chdir(File.dirname($0)) {
-  command = "sem-apply --host localhost --user %%user%% --name %%name%%"
+  command = "sem-apply --url %%url%%"
   puts command
   exec(command)
 }

--- a/test/init.rb
+++ b/test/init.rb
@@ -16,18 +16,18 @@ module TestUtils
   def TestUtils.create_db_config(opts={})
     name = opts.delete(:name) || TestUtils.random_db_name
     SchemaEvolutionManager::Preconditions.check_state(opts.empty?)
-    SchemaEvolutionManager::Db.parse_command_line_config("--host localhost --name #{name} --user postgres")
+    SchemaEvolutionManager::Db.parse_command_line_config("--url postgresql://localhost:5432:#{name}")
   end
 
   def TestUtils.with_db
-    superdb = SchemaEvolutionManager::Db.new("localhost", "postgres", "postgres")
+    superdb = SchemaEvolutionManager::Db.new("postgresql://localhost:5432:postgres")
     name = "schema_evolution_manager_test_db_%s" % [rand(100000)]
     db = SchemaEvolutionManager::Db.parse_command_line_config("--host localhost --name #{name} --user postgres")
     begin
-      superdb.psql_command("create database #{db.name}")
+      superdb.psql_command("create database #{name}")
       yield db
     ensure
-      superdb.psql_command("drop database #{db.name}")
+      superdb.psql_command("drop database #{name}")
     end
   end
 

--- a/test/init.rb
+++ b/test/init.rb
@@ -16,11 +16,11 @@ module TestUtils
   def TestUtils.create_db_config(opts={})
     name = opts.delete(:name) || TestUtils.random_db_name
     SchemaEvolutionManager::Preconditions.check_state(opts.empty?)
-    SchemaEvolutionManager::Db.parse_command_line_config("--url postgresql://localhost:5432:#{name}")
+    SchemaEvolutionManager::Db.parse_command_line_config("--url postgresql://localhost:5432/#{name}")
   end
 
   def TestUtils.with_db
-    superdb = SchemaEvolutionManager::Db.new("postgresql://localhost:5432:postgres")
+    superdb = SchemaEvolutionManager::Db.new("postgresql://localhost:5432/postgres")
     name = "schema_evolution_manager_test_db_%s" % [rand(100000)]
     db = SchemaEvolutionManager::Db.parse_command_line_config("--host localhost --name #{name} --user postgres")
     begin

--- a/test/specs/bin/sem_apply_spec.rb
+++ b/test/specs/bin/sem_apply_spec.rb
@@ -21,7 +21,7 @@ describe "Apply" do
   it "does not apply sql scripts with dry_run" do
     with_script_setup do |db|
       apply_path = File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-apply")
-      SchemaEvolutionManager::Library.system_or_error("#{apply_path} --host #{db.host} --name #{db.name} --user #{db.user} --dry_run")
+      SchemaEvolutionManager::Library.system_or_error("#{apply_path} --url #{db.url} --dry_run")
       lambda {
         db.psql_command("select count(*) from tmp")
       }.should raise_error(RuntimeError)
@@ -31,7 +31,7 @@ describe "Apply" do
   it "applies sql scripts without dry_run" do
     with_script_setup do |db|
       apply_path = File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-apply")
-      SchemaEvolutionManager::Library.system_or_error("#{apply_path} --host #{db.host} --name #{db.name} --user #{db.user}")
+      SchemaEvolutionManager::Library.system_or_error("#{apply_path} --url #{db.url}")
       db.psql_command("select count(*) from tmp").to_i.should == 1
     end
   end

--- a/test/specs/bin/sem_init_spec.rb
+++ b/test/specs/bin/sem_init_spec.rb
@@ -8,7 +8,7 @@ describe "Init" do
     TestUtils.with_bootstrapped_db do |db|
       SchemaEvolutionManager::Library.with_temp_file do |tmp|
         SchemaEvolutionManager::Library.system_or_error("git init #{tmp}")
-        SchemaEvolutionManager::Library.system_or_error("#{init_path} --dir #{tmp} --name #{db.name} --user #{db.user}")
+        SchemaEvolutionManager::Library.system_or_error("#{init_path} --dir #{tmp} --name test --user postgres")
       end
     end
   end

--- a/test/specs/bin/sem_init_spec.rb
+++ b/test/specs/bin/sem_init_spec.rb
@@ -8,7 +8,7 @@ describe "Init" do
     TestUtils.with_bootstrapped_db do |db|
       SchemaEvolutionManager::Library.with_temp_file do |tmp|
         SchemaEvolutionManager::Library.system_or_error("git init #{tmp}")
-        SchemaEvolutionManager::Library.system_or_error("#{init_path} --dir #{tmp} --name test --user postgres")
+        SchemaEvolutionManager::Library.system_or_error("#{init_path} --dir #{tmp} --url #{db.url}")
       end
     end
   end

--- a/test/specs/lib/apply_util_spec.rb
+++ b/test/specs/lib/apply_util_spec.rb
@@ -15,7 +15,7 @@ describe SchemaEvolutionManager::ApplyUtil do
   end
 
   it "dry_run?" do
-    db = SchemaEvolutionManager::Db.new("localhost", "test", "postgres")
+    db = SchemaEvolutionManager::Db.new("postgres://postgres@localhost/test")
     SchemaEvolutionManager::ApplyUtil.new(db).dry_run?.should be_true
     SchemaEvolutionManager::ApplyUtil.new(db, :dry_run => nil).dry_run?.should be_true
     SchemaEvolutionManager::ApplyUtil.new(db, :dry_run => true).dry_run?.should be_true

--- a/test/specs/lib/db_spec.rb
+++ b/test/specs/lib/db_spec.rb
@@ -4,9 +4,7 @@ describe SchemaEvolutionManager::Db do
 
   it "SchemaEvolutionManager::Db.parse_command_line_config" do
     db = TestUtils.create_db_config(:name => "test")
-    db.host.should == "localhost"
-    db.name.should == "test"
-    db.user.should == "postgres"
+    db.url.should == "postgresql://localhost:5432/test"
   end
 
   it "SchemaEvolutionManager::Db.schema_name" do

--- a/test/specs/lib/db_spec.rb
+++ b/test/specs/lib/db_spec.rb
@@ -50,11 +50,6 @@ describe SchemaEvolutionManager::Db do
     end
   end
 
-  it "to_pretty_string" do
-    db = TestUtils.create_db_config(:name => "test")
-    db.to_pretty_string.should == "postgres@localhost/test"
-  end
-
   it "psql_command" do
     TestUtils.with_db do |db|
       db.psql_command("select 10").should == "10"

--- a/test/specs/lib/scripts_spec.rb
+++ b/test/specs/lib/scripts_spec.rb
@@ -30,7 +30,7 @@ describe SchemaEvolutionManager::Scripts do
   it "creates all scripts table" do
     TestUtils.with_bootstrapped_db do |db|
       tables = db.psql_command("select table_name from information_schema.tables where table_schema ='%s'" % [SchemaEvolutionManager::Db.schema_name])
-      tables.map(&:strip).sort.join(" ").should == SchemaEvolutionManager::Scripts::VALID_TABLE_NAMES.sort.join(" ")
+      tables.split("\n").map(&:strip).sort.join(" ").should == SchemaEvolutionManager::Scripts::VALID_TABLE_NAMES.sort.join(" ")
     end
   end
 


### PR DESCRIPTION
Modifies sem-apply to accept a --url parameter containing a connection string
for the psql database to which we are applying changes.

Connection string format follows psql:

 - Example: postgresql://postgres@localhost/sample_development
 - See https://jdbc.postgresql.org/documentation/head/connect.html

Original proposal at https://github.com/mbryzek/schema-evolution-manager/pull/21
