### PR TITLE
Ensure psqlrc is not run in postgres 9.6

### DIFF
--- a/lib/schema-evolution-manager/db.rb
+++ b/lib/schema-evolution-manager/db.rb
@@ -28,7 +28,7 @@ module SchemaEvolutionManager
     # executes a simple sql command.
     def psql_command(sql_command)
       Preconditions.assert_class(sql_command, String)
-      command = "psql --no-align --tuples-only --command \"%s\" %s" % [sql_command, @url]
+      command = "psql --no-align --tuples-only --no-psqlrc --command \"%s\" %s" % [sql_command, @url]
       Library.system_or_error(command)
     end
 


### PR DESCRIPTION
In postgresql 9.6, the behavior of psql -c was changed such that it no longer implies --no-psqlrc.

Depending on the contents of ~/.psqlrc, this can cause additional output to be included in the result of psql_command().

```
def schema_schema_evolution_manager_exists?
  sql = "select count(*) from pg_namespace where nspname='%s'" % Db.schema_name
  psql_command(sql).to_i > 0
end
```

If ~/.psqlrc contains something like `SET client_encoding = 'UTF8';`
This command will be checking `"SET\n1".to_i` which is 0, making SEM attempt to re-bootstrap the database.

According to the postgres 9.6 changelog, adding --no-psqlrc should be backwards-compatible with older psql versions.

```
psql's -c option no longer implies --no-psqlrc (Pavel Stehule, Catalin Iacob)

Write --no-psqlrc (or its abbreviation -X) explicitly to obtain the old behavior. Scripts so modified will still work with old versions of psql.
```

I'm not sure if this should also be added to Db.attribute_values?