### PR TITLE
Handle nil response when asking for input

### DIFF
--- a/lib/schema-evolution-manager/ask.rb
+++ b/lib/schema-evolution-manager/ask.rb
@@ -24,7 +24,7 @@ module SchemaEvolutionManager
       value = nil
       while value.to_s == ""
         print final_message
-        value = get_input(echo).strip
+        value = get_input(echo).to_s.strip
         if value.to_s == "" && default
           value = default.to_s.strip
         end

--- a/test/specs/lib/ask_spec.rb
+++ b/test/specs/lib/ask_spec.rb
@@ -2,19 +2,28 @@ load File.join(File.dirname(__FILE__), '../../init.rb')
 
 describe SchemaEvolutionManager::Ask do
 
-  it "SchemaEvolutionManager::Ask.for_string" do
-    SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("hello world")
-    SchemaEvolutionManager::Ask.for_string("Testing").should == "hello world"
-  end
+  describe "SchemaEvolutionManager::Ask.for_string" do
 
-  it "SchemaEvolutionManager::Ask.for_string trims input" do
-    SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("   Hello world  ")
-    SchemaEvolutionManager::Ask.for_string("Testing").should == "Hello world"
-  end
+    it "works" do
+      SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("hello world")
+      SchemaEvolutionManager::Ask.for_string("Testing").should == "hello world"
+    end
 
-  it "SchemaEvolutionManager::Ask.for_string with default" do
-    SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("")
-    SchemaEvolutionManager::Ask.for_string("Testing", :default => "  hello world  ").should == "hello world"
+    it "trims input" do
+      SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("   Hello world  ")
+      SchemaEvolutionManager::Ask.for_string("Testing").should == "Hello world"
+    end
+
+    it "uses default" do
+      SchemaEvolutionManager::Ask.should_receive(:get_input).and_return("")
+      SchemaEvolutionManager::Ask.for_string("Testing", :default => "  hello world  ").should == "hello world"
+    end
+
+    it "does not fail with no input" do
+      SchemaEvolutionManager::Ask.should_receive(:get_input).and_return(nil)
+      SchemaEvolutionManager::Ask.for_string("Testing", :default => "hello world").should == "hello world"
+    end
+
   end
 
   describe "SchemaEvolutionManager::Ask.for_boolean" do


### PR DESCRIPTION
This happens when a script is called by an automated script and
there is no opportunity for human input. In this case, the default
will be used.