### PR TITLE
Unbreak version

### DIFF
--- a/lib/schema-evolution-manager/sem_version.rb
+++ b/lib/schema-evolution-manager/sem_version.rb
@@ -1,12 +1,10 @@
 # File automatically created and updated by util/create-release.rb
 module SchemaEvolutionManager
 
-module SemVersion
+  module SemVersion
 
-VERSION ||= '0.9.43'
+    VERSION ||= '0.9.43'
 
-end
-
-end
+  end
 
 end

--- a/util/create-release.rb
+++ b/util/create-release.rb
@@ -52,7 +52,6 @@ File.open(sem_version_path, "w") do |out|
   out << "module SemVersion\n\n"
   out << "VERSION ||= '0.9.43'\n\n"
   out << "end\n\n"
-  out << "end\n\n"
   out << "end\n"
 end
 


### PR DESCRIPTION
Current version of package has syntax errors in sem_version.rb

```bash
/Users/matija/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/schema-evolution-manager-0.9.44/lib/schema-evolution-manager.rb:15:in `load': /Users/matija/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/schema-evolution-manager-0.9.44/lib/schema-evolution-manager/sem_version.rb:12: syntax error, unexpected `end', expecting end-of-input (SyntaxError)
from /Users/matija/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/schema-evolution-manager-0.9.44/lib/schema-evolution-manager.rb:15:in `<top (required)>'
```