### PR TITLE
Update git manual install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ There are two ways to install schema evolution manager:
 
 1. Direct install using ruby (no dependency on ruby gems)
 
-        git clone git://github.com/mbryzek/schema-evolution-manager.git
+        git clone git@github.com:mbryzek/schema-evolution-manager.git
         cd schema-evolution-manager
         git checkout 0.9.45
         ruby ./configure.rb


### PR DESCRIPTION
Github no longer allows the use of `git://` when cloning repo:

```❯ git clone git://github.com/mbryzek/schema-evolution-manager.git
Cloning into 'schema-evolution-manager'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Updated the command to use `git@github.com:mbryzek/schema-evolution-manager.git`