### PR TITLE
Fix Unicode crash in migration attribute parser (#39)

### DIFF
--- a/lib/schema-evolution-manager/migration_file.rb
+++ b/lib/schema-evolution-manager/migration_file.rb
@@ -77,21 +77,22 @@ module SchemaEvolutionManager
     # -- sem.attribute.name = value
     #
     # and yields each matching row with |name, value|
+    #
+    # Read in binary mode so the shell locale (e.g. LANG=C in a minimal
+    # Docker image) cannot tag UTF-8 bytes as US-ASCII and cause String#strip
+    # to raise Encoding::CompatibilityError. Attribute lines are strict ASCII;
+    # scrubbing invalid bytes on non-attribute lines is harmless.
     def each_property
-      IO.readlines(path).each do |l|
-        begin
-          stripped = l.strip.encode("UTF-8")
-          if stripped.match(/^\-\-\s+sem\.attribute\./)
-            stripped.sub!(/^\-\-\s+sem\.attribute\./, '')
-            name, value = stripped.split(/\=/, 2).map(&:strip)
-            yield name, value
-          end
-        rescue Encoding::InvalidByteSequenceError
-          # Ignore - attributes must be in ascii
+      File.foreach(path, mode: "rb") do |raw|
+        line = raw.force_encoding("UTF-8")
+        line = line.scrub unless line.valid_encoding?
+        stripped = line.strip
+        if stripped.match(/^\-\-\s+sem\.attribute\./)
+          stripped.sub!(/^\-\-\s+sem\.attribute\./, '')
+          name, value = stripped.split(/\=/, 2).map(&:strip)
+          yield name, value
         end
       end
-    rescue Encoding::InvalidByteSequenceError
-      # Ignore - file must be in ascii in order to parse attributes
     end
 
   end

--- a/test/specs/lib/migration_file_spec.rb
+++ b/test/specs/lib/migration_file_spec.rb
@@ -96,4 +96,32 @@ select 1
     end
   end
 
+  # Regression for https://github.com/mbryzek/schema-evolution-manager/issues/39
+  # UTF-8 characters in a migration must not blow up attribute parsing even
+  # when the shell locale tags file bytes as US-ASCII (e.g. LANG=C in Docker).
+  it "parses attributes when file contains UTF-8 and locale is ASCII" do
+    command = <<-eos
+-- sem.attribute.transaction=none
+INSERT INTO currency VALUES ('ISK', 'Icelandic króna');
+INSERT INTO currency VALUES ('STD', 'São Tomé and Príncipe dobra');
+INSERT INTO currency VALUES ('TOP', 'Tongan paʻanga');
+    eos
+    TestUtils.in_test_repo_with_script(:sql_command => command) do |path|
+      original_external = Encoding.default_external
+      begin
+        Encoding.default_external = Encoding::US_ASCII
+        verify_transaction_value(SchemaEvolutionManager::MigrationFile.new(path).attribute_values, "none")
+      ensure
+        Encoding.default_external = original_external
+      end
+    end
+  end
+
+  it "parses attributes when file contains genuinely invalid UTF-8 bytes" do
+    command = "-- sem.attribute.transaction=none\nINSERT INTO t VALUES ('\xFF\xFE garbage');\n"
+    TestUtils.in_test_repo_with_script(:sql_command => command) do |path|
+      verify_transaction_value(SchemaEvolutionManager::MigrationFile.new(path).attribute_values, "none")
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary
- Closes #39. The attribute parser in `migration_file.rb` still crashed on migration files containing UTF-8 characters (`króna`, `São Tomé`, `tögrög`, etc.) when run under a non-UTF-8 shell locale — the exact scenario the original reporter hit in a Docker container with `LANG=C`.
- The 2016 fix (0.9.31) rescued `Encoding::InvalidByteSequenceError`, but under an ASCII locale `IO.readlines` tags UTF-8 bytes as US-ASCII and `String#strip` raises `Encoding::CompatibilityError` — a different `EncodingError` subclass, so the rescue missed it. Reproduced on current `main` (0.9.57) before fixing.
- Switched to `File.foreach(path, mode: "rb")` + `force_encoding("UTF-8")` + `scrub` (only when invalid). Attribute lines are strict ASCII, so scrubbing non-attribute lines is a no-op. Both rescues removed — the failure mode is now designed out rather than caught.

## Test plan
- [x] `rspec test/specs/lib/migration_file_spec.rb` — 13 examples pass (was 12 + 1 new locale-mismatch test + 1 new invalid-bytes test).
- [x] Verified new locale-mismatch test fails on the old code with `Encoding::CompatibilityError` (the exact class the old rescue missed).
- [x] Reproduced the original bug on `main` with a UTF-8 SQL file under `LANG=C LC_ALL=C`; confirmed the fix resolves it.
- [ ] Maintainer sanity-check on Ruby version matrix if CI covers multiple Rubies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)