### PR TITLE
Fix test harness: stop swallowing failures in with_db; fix psql_file spec

### DIFF
--- a/test/init.rb
+++ b/test/init.rb
@@ -26,9 +26,6 @@ module TestUtils
     begin
       superdb.psql_command("create database #{name}")
       yield db
-    rescue Exception => e
-      puts e.message
-      puts e.backtrace.inspect
     ensure
       superdb.psql_command("drop database #{name}")
     end

--- a/test/specs/lib/db_spec.rb
+++ b/test/specs/lib/db_spec.rb
@@ -56,9 +56,11 @@ describe SchemaEvolutionManager::Db do
 
   it "psql_file" do
     TestUtils.with_db do |db|
-      SchemaEvolutionManager::Library.write_to_temp_file("select 10") do |path|
-        db.psql_file(path).should == "10"
+      sql = "create table psql_file_test (id integer); insert into psql_file_test (id) values (10);"
+      SchemaEvolutionManager::Library.write_to_temp_file(sql) do |path|
+        db.psql_file("20130318-105434.sql", path)
       end
+      db.psql_command("select id from psql_file_test").should == "10"
     end
   end
 


### PR DESCRIPTION
Fixes two **pre-existing** test-harness issues (found while implementing #86, unrelated to that feature). Plan: `~/code/claude/plans/2026-07-17-sem-test-harness-preexisting-issues.md`.

## Issue 1 — `TestUtils.with_db` swallowed failures → false-green
`with_db` wrapped the yielded block in `rescue Exception => e; puts ...`, catching **everything** raised inside — including RSpec's `ExpectationNotMetError`. A failing assertion inside a `with_db`/`with_bootstrapped_db` block printed its message but the example still passed with 0 failures. Every DB-backed spec was effectively unable to fail.

**Fix:** removed the `rescue`; the `ensure` block still drops the database, so failures now propagate to RSpec.

## Issue 2 — `psql_file` spec was broken (hidden by Issue 1)
`db_spec.rb` called `db.psql_file(path)` but the method signature is `psql_file(filename, path)` — an `ArgumentError` that was silently swallowed. Additionally, `psql_file` returns `nil` on success (it executes a file and only raises on error), so the old `.should == "10"` assertion was never meaningful.

**Fix:** rewrote the spec to test what `psql_file` actually does — execute a file's SQL — and verify the side effect via `psql_command`.

## Verification
- Full suite: **146 examples, 0 failures** (with failure-swallowing removed, confirming no other latent failures were hidden).
- Proved the honesty fix: deliberately breaking an in-`with_db` assertion now reports **1 failure** (previously false-greened at 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mbryzek/schema-evolution-manager/87)
<!-- Reviewable:end -->
