### PR TITLE
feat(sem): friendly errors for sem-info db

### DIFF
--- a/lib/schema-evolution-manager/sem_info.rb
+++ b/lib/schema-evolution-manager/sem_info.rb
@@ -12,23 +12,49 @@ module SchemaEvolutionManager
 
       if !valid.include?(subcommand)
         if subcommand.empty?
-          puts "ERROR: Missing db subcommand. Must be one of: %s" % valid.join(", ")
+          $stderr.puts "ERROR: Missing db subcommand. Must be one of: %s" % valid.join(", ")
         else
-          puts "ERROR: Invalid db subcommand[%s]. Must be one of: %s" % [subcommand, valid.join(", ")]
+          $stderr.puts "ERROR: Invalid db subcommand[%s]. Must be one of: %s" % [subcommand, valid.join(", ")]
         end
         exit(4)
       end
 
       db_args = SchemaEvolutionManager::Args.new(args.join(" "), :optional => ['url', 'host', 'user', 'name', 'port', 'set'])
-      db = SchemaEvolutionManager::Db.from_args(db_args)
 
-      if subcommand == "version"
-        version = SchemaEvolutionManager::Versions.new(db).latest
-        puts version unless version.nil?
-      elsif subcommand == "scripts"
-        SchemaEvolutionManager::Scripts.new(db, SchemaEvolutionManager::Scripts::SCRIPTS).applied.each do |filename|
-          puts filename
+      if db_args.url.to_s.strip.empty? && db_args.name.to_s.strip.empty?
+        $stderr.puts "ERROR: Missing database connection. Provide --url <postgres url> or --host/--name."
+        exit(3)
+      end
+
+      # A common mistake is passing a bare database name to --url. Catch it with
+      # an actionable hint instead of letting parse_url raise a raw backtrace.
+      if db_args.url && !db_args.url.include?("://")
+        $stderr.puts "ERROR: --url must be a full connection string (e.g. postgres://localhost:5432/%s). To connect by database name, use --name %s." % [db_args.url, db_args.url]
+        exit(3)
+      end
+
+      begin
+        db = SchemaEvolutionManager::Db.from_args(db_args)
+        if subcommand == "version"
+          version = SchemaEvolutionManager::Versions.new(db).latest
+          if version.nil?
+            $stderr.puts "No deployed version recorded"
+          else
+            puts version
+          end
+        elsif subcommand == "scripts"
+          applied = SchemaEvolutionManager::Scripts.new(db, SchemaEvolutionManager::Scripts::SCRIPTS).applied
+          if applied.empty?
+            $stderr.puts "No scripts recorded"
+          else
+            applied.each { |filename| puts filename }
+          end
         end
+      rescue => e
+        # Surface a single clean line (e.g. bad url, unreachable host, missing
+        # database) rather than a Ruby stack trace.
+        $stderr.puts "ERROR: %s" % e.message.to_s.split("\n").first
+        exit(3)
       end
     end
 

--- a/test/specs/bin/sem_info_spec.rb
+++ b/test/specs/bin/sem_info_spec.rb
@@ -46,13 +46,34 @@ describe "sem-info" do
     output.should == "3.1.4"
   end
 
-  it "db version is blank when nothing recorded" do
+  it "db version reports clearly when nothing is recorded" do
     info_path = File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-info")
-    output = nil
+    stdout = nil
+    combined = nil
     TestUtils.with_bootstrapped_db do |db|
-      output = `#{info_path} db version --url #{db.url}`.strip
+      stdout = `#{info_path} db version --url #{db.url}`.strip
+      combined = `#{info_path} db version --url #{db.url} 2>&1`.strip
     end
-    output.should == ""
+    stdout.should == ""                                 # stdout stays clean for scripting
+    combined.should == "No deployed version recorded"   # but the user sees a message
+  end
+
+  it "db version errors clearly when no connection is provided" do
+    info_path = File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-info")
+    output = `#{info_path} db version 2>&1`
+    status = $?.exitstatus
+    status.should_not == 0
+    output.should match(/Missing database connection/)
+    output.should_not match(/\.rb:\d+/)   # no ruby backtrace
+  end
+
+  it "db version gives a friendly, actionable error for a bare-name --url" do
+    info_path = File.join(SchemaEvolutionManager::Library.base_dir, "bin/sem-info")
+    output = `#{info_path} db version --url platformdb 2>&1`
+    status = $?.exitstatus
+    status.should_not == 0
+    output.should match(/--name platformdb/)                        # actionable hint
+    output.should_not match(/RuntimeError|parse_url|\.rb:\d+/)      # no ruby backtrace
   end
 
   it "db scripts lists applied script filenames" do


### PR DESCRIPTION
## What

Makes `sem-info db version|scripts` friendly on every bad-input path. Follows the merged Phase-1 tracking feature (#86).

Before, three cases gave confusing output:
- `sem-info db version` (no connection) → silently connected to a default database and printed a **blank line**.
- `sem-info db version --url platformdb` (bare name, not a URL) → dumped a **raw Ruby stack trace** (`parse_url: Invalid url... (RuntimeError)`).
- Connected but nothing recorded → **blank line**, no indication whether it worked.

## How

- **Missing connection** → `ERROR: Missing database connection. Provide --url <postgres url> or --host/--name.` (exit 3)
- **Bare-name `--url`** → `ERROR: --url must be a full connection string (e.g. postgres://localhost:5432/platformdb). To connect by database name, use --name platformdb.` (exit 3) — actionable, no backtrace
- **No version / no scripts recorded** → `No deployed version recorded` / `No scripts recorded` on **stderr** (exit 0), so stdout stays clean for scripting
- DB operations wrapped so connection/url errors surface as a **single clean line**, never a stack trace
- All messages routed to stderr

## Testing

- Full suite green: **148 examples, 0 failures**.
- TDD: added tests for the missing-connection error, the bare-name-`--url` hint (asserts no `.rb:NN` backtrace), and the no-version message (asserts clean stdout + message on stderr).
- Manually reproduced all three of the reported cases and confirmed the new output; verified the `--name` form the hint points to actually connects and returns the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mbryzek/schema-evolution-manager/88)
<!-- Reviewable:end -->
